### PR TITLE
Add Receiver concept

### DIFF
--- a/glucose-badge.xcodeproj/project.pbxproj
+++ b/glucose-badge.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		65FE24237AAAEA4600318C88 /* Pods_glucose_badge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D59996DF47C494AD554AD76F /* Pods_glucose_badge.framework */; };
+		954A962E1C4D57210018C878 /* Receiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954A962D1C4D57210018C878 /* Receiver.swift */; };
+		954A96301C4D5EF20018C878 /* ReceiverNotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954A962F1C4D5EF20018C878 /* ReceiverNotificationDelegate.swift */; };
+		954A96321C4D5FA20018C878 /* StaticValuesReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954A96311C4D5FA20018C878 /* StaticValuesReceiver.swift */; };
+		954A96341C4D652B0018C878 /* Reading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954A96331C4D652B0018C878 /* Reading.swift */; };
 		9593CE3E1C135D1600D45B22 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9593CE3D1C135D1600D45B22 /* AppDelegate.swift */; };
 		9593CE401C135D1600D45B22 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9593CE3F1C135D1600D45B22 /* ViewController.swift */; };
 		9593CE431C135D1600D45B22 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9593CE411C135D1600D45B22 /* Main.storyboard */; };
@@ -18,6 +22,10 @@
 
 /* Begin PBXFileReference section */
 		74F4CB503FB8269984F1277D /* Pods-glucose-badge.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-glucose-badge.release.xcconfig"; path = "Pods/Target Support Files/Pods-glucose-badge/Pods-glucose-badge.release.xcconfig"; sourceTree = "<group>"; };
+		954A962D1C4D57210018C878 /* Receiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Receiver.swift; sourceTree = "<group>"; };
+		954A962F1C4D5EF20018C878 /* ReceiverNotificationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiverNotificationDelegate.swift; sourceTree = "<group>"; };
+		954A96311C4D5FA20018C878 /* StaticValuesReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticValuesReceiver.swift; sourceTree = "<group>"; };
+		954A96331C4D652B0018C878 /* Reading.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reading.swift; sourceTree = "<group>"; };
 		9593CE3A1C135D1600D45B22 /* glucose-badge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "glucose-badge.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9593CE3D1C135D1600D45B22 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9593CE3F1C135D1600D45B22 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -51,6 +59,17 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		954A962C1C4D56BD0018C878 /* transmitters */ = {
+			isa = PBXGroup;
+			children = (
+				954A962D1C4D57210018C878 /* Receiver.swift */,
+				954A96311C4D5FA20018C878 /* StaticValuesReceiver.swift */,
+				954A962F1C4D5EF20018C878 /* ReceiverNotificationDelegate.swift */,
+				954A96331C4D652B0018C878 /* Reading.swift */,
+			);
+			name = transmitters;
+			sourceTree = "<group>";
+		};
 		9593CE311C135D1600D45B22 = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +91,7 @@
 		9593CE3C1C135D1600D45B22 /* glucose-badge */ = {
 			isa = PBXGroup;
 			children = (
+				954A962C1C4D56BD0018C878 /* transmitters */,
 				9593CE3D1C135D1600D45B22 /* AppDelegate.swift */,
 				9593CE3F1C135D1600D45B22 /* ViewController.swift */,
 				9593CE411C135D1600D45B22 /* Main.storyboard */,
@@ -219,8 +239,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				954A96321C4D5FA20018C878 /* StaticValuesReceiver.swift in Sources */,
+				954A96341C4D652B0018C878 /* Reading.swift in Sources */,
+				954A96301C4D5EF20018C878 /* ReceiverNotificationDelegate.swift in Sources */,
 				9593CE401C135D1600D45B22 /* ViewController.swift in Sources */,
 				9593CE3E1C135D1600D45B22 /* AppDelegate.swift in Sources */,
+				954A962E1C4D57210018C878 /* Receiver.swift in Sources */,
 				9593CE501C13686A00D45B22 /* NSUserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/glucose-badge/AppDelegate.swift
+++ b/glucose-badge/AppDelegate.swift
@@ -7,26 +7,19 @@
 //
 
 import UIKit
-import CoreBluetooth
-import xDripG5
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, ReceiverNotificationDelegate {
 
     var window: UIWindow?
     var app: UIApplication!
-    var transmitter: Transmitter?
+    var receiver: Receiver?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         self.app = application
-
-        transmitter = Transmitter(
-            ID: NSUserDefaults.standardUserDefaults().transmitterId,
-            startTimeInterval: nil,
-            passiveModeEnabled: true
-        )
-        transmitter?.stayConnected = true
-        transmitter?.delegate = self
+        self.receiver = createReceiver()
+        self.receiver?.readingNotifier = self
+        self.receiver?.connect()
 
         self.resignFirstResponder()
 
@@ -39,13 +32,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
         return true
     }
 
-
-    func transmitter(transmitter: Transmitter, didReadGlucose glucose: GlucoseRxMessage){
-        app.applicationIconBadgeNumber = Int(glucose.glucose)
+    private func createReceiver() -> Receiver? {
+        return StaticValuesReceiver(
+            readings: [Reading(value:70, timestamp:NSDate()), Reading(value:80, timestamp:NSDate())],
+            valueChangeInterval: 2.5
+        )
     }
 
-    func transmitter(transmitter: Transmitter, didError error: ErrorType){
-        app.applicationIconBadgeNumber = -1
+    func receiver(receiver: Receiver, didReceiveReading: Reading) {
+        app.applicationIconBadgeNumber = Int(didReceiveReading.value)
     }
 
     func applicationWillResignActive(application: UIApplication) {

--- a/glucose-badge/Base.lproj/Main.storyboard
+++ b/glucose-badge/Base.lproj/Main.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="glucose_lock" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="glucose_badge" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -19,42 +19,35 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Transmitter ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wfo-D3-xTz" userLabel="Transmitter ID Label">
                                 <rect key="frame" x="20" y="101" width="114" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Show on Badge" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zkh-aG-jco" userLabel="Show on Badge Label">
                                 <rect key="frame" x="20" y="140" width="120" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Show on Lock Screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JDv-vR-fDY" userLabel="Show on Lock Screen Label">
                                 <rect key="frame" x="20" y="185" width="165" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KHf-z0-U67" userLabel="Show on Lock Screen Switch">
                                 <rect key="frame" x="193" y="180" width="51" height="31"/>
-                                <animations/>
                             </switch>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="piu-Ge-t0k" userLabel="Show on Badge Switch">
                                 <rect key="frame" x="193" y="135" width="51" height="31"/>
-                                <animations/>
                             </switch>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="TX6-yC-bAA" userLabel="Transmitter ID Entry">
                                 <rect key="frame" x="193" y="97" width="133" height="30"/>
-                                <animations/>
                                 <accessibility key="accessibilityConfiguration" label=""/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="allCharacters" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
                             </textField>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <connections>

--- a/glucose-badge/Reading.swift
+++ b/glucose-badge/Reading.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal struct Reading {
-    var value: UInt16?
+    var value: UInt16
     var timestamp: NSDate
 
     internal init(value: UInt16, timestamp: NSDate){

--- a/glucose-badge/Reading.swift
+++ b/glucose-badge/Reading.swift
@@ -1,0 +1,19 @@
+//
+//  Reading.swift
+//  glucose-badge
+//
+//  Created by Dennis Gove on 1/18/16.
+//  Copyright © 2016 gove. All rights reserved.
+//
+
+import Foundation
+
+internal struct Reading {
+    var value: UInt16?
+    var timestamp: NSDate
+
+    internal init(value: UInt16, timestamp: NSDate){
+        self.value = value
+        self.timestamp = timestamp
+    }
+}

--- a/glucose-badge/Receiver.swift
+++ b/glucose-badge/Receiver.swift
@@ -1,0 +1,25 @@
+//
+//  Receiver.swift
+//  glucose-badge
+//
+//  Created by Dennis Gove on 1/18/16.
+//  Copyright © 2016 gove. All rights reserved.
+//
+
+import Foundation
+
+protocol Receiver : class {
+
+    // Open conection with the underlying transmitter.
+    // If already open then considered a no-op
+    func connect() -> Bool
+
+    // Close connectino with the underlying transmitter
+    // If already closed then considered a no-op
+    func disconnect() -> Bool
+
+    var readingNotifier: ReceiverNotificationDelegate? {
+        get
+        set
+    }
+}

--- a/glucose-badge/ReceiverNotificationDelegate.swift
+++ b/glucose-badge/ReceiverNotificationDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  ReceiverNotificationDelegate.swift
+//  glucose-badge
+//
+//  Created by Dennis Gove on 1/18/16.
+//  Copyright © 2016 gove. All rights reserved.
+//
+
+import Foundation
+
+protocol ReceiverNotificationDelegate: class {
+    func receiver(receiver: Receiver, didReceiveReading: Reading)
+
+    // TODO: decide if we need a designated error callback. Perhaps Reading can
+    // become a protocol that can have GlucoseReading and ErrorReading
+//    func receiver(receiver: Receiver, didReceiverError: ReceiverError)
+
+//    func communicationLost(receiver: Receiver)
+
+//    func communicationGained(receiver: Receiver)
+}

--- a/glucose-badge/StaticValuesReceiver.swift
+++ b/glucose-badge/StaticValuesReceiver.swift
@@ -1,0 +1,65 @@
+//
+//  StaticValuesReceiver.swift
+//  glucose-badge
+//
+//  Created by Dennis Gove on 1/18/16.
+//  Copyright © 2016 gove. All rights reserved.
+//
+
+import Foundation
+
+// Implements a receiver which will iterate through a list of static
+// values at some fixed rate. This can be used for testing purposes.
+//
+// TODO: Move this into a standard swift testing set
+
+class StaticValuesReceiver : Receiver {
+
+    private var notifier: ReceiverNotificationDelegate?
+    private var readings: [Reading]?
+    private var valueChangeInterval: Double
+    private var valueSender: NSTimer?
+    private var nextValueIdx: Int
+
+    internal init(readings: [Reading]?, valueChangeInterval: Double) {
+        self.readings = readings
+        self.valueChangeInterval = valueChangeInterval
+        self.nextValueIdx = 0
+    }
+
+    // Begin sending values through the notifier
+    // Returns false if no values exist to send or notifier is null
+    func connect() -> Bool {
+        if(nil == self.notifier || nil == self.readings || 0 == self.readings?.count){
+            return false
+        }
+
+        if(nil == valueSender){
+            valueSender = NSTimer.scheduledTimerWithTimeInterval(valueChangeInterval, target: self, selector: "sendNextValue", userInfo: nil, repeats: true)
+        }
+        return true
+    }
+
+    // Stop sending values through the notifier
+    // Always returns true
+    func disconnect() -> Bool {
+        if(nil != valueSender){
+            valueSender?.invalidate()
+            valueSender = nil
+        }
+        return true
+    }
+
+    var readingNotifier: ReceiverNotificationDelegate? {
+        get{ return self.notifier }
+        set{ self.notifier = newValue }
+    }
+
+    private func sendNextValue() {
+        if(nil != notifier && nil != readings){
+            notifier?.receiver(self, didReceiveReading: readings![nextValueIdx])
+            nextValueIdx = (nextValueIdx + 1) % readings!.count
+        }
+    }
+
+}

--- a/glucose-badge/StaticValuesReceiver.swift
+++ b/glucose-badge/StaticValuesReceiver.swift
@@ -13,7 +13,7 @@ import Foundation
 //
 // TODO: Move this into a standard swift testing set
 
-class StaticValuesReceiver : Receiver {
+class StaticValuesReceiver : NSObject, Receiver {
 
     private var notifier: ReceiverNotificationDelegate?
     private var readings: [Reading]?
@@ -25,6 +25,14 @@ class StaticValuesReceiver : Receiver {
         self.readings = readings
         self.valueChangeInterval = valueChangeInterval
         self.nextValueIdx = 0
+    }
+
+
+    func sendNextValue() {
+        if(nil != notifier && nil != readings){
+            notifier?.receiver(self, didReceiveReading: readings![nextValueIdx])
+            nextValueIdx = (nextValueIdx + 1) % readings!.count
+        }
     }
 
     // Begin sending values through the notifier
@@ -53,13 +61,6 @@ class StaticValuesReceiver : Receiver {
     var readingNotifier: ReceiverNotificationDelegate? {
         get{ return self.notifier }
         set{ self.notifier = newValue }
-    }
-
-    private func sendNextValue() {
-        if(nil != notifier && nil != readings){
-            notifier?.receiver(self, didReceiveReading: readings![nextValueIdx])
-            nextValueIdx = (nextValueIdx + 1) % readings!.count
-        }
     }
 
 }


### PR DESCRIPTION
Adds the concept of a Receiver which will be used to power the main application. This removes Transmitter from the main application code and instead allows us to wrap various types of Transmitters in Receiver objects. Doing this allows us to create test-only receivers and makes us less dependent on the implementation of various Transmitters.

Still work to be done to actually integrate this. And of course wrapping up xDripG5.Transmitter.
